### PR TITLE
Use exec to forward signals like SIGTERM to gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,5 @@ ENV WORKER_COUNT=4
 
 HEALTHCHECK --interval=2s --timeout=2s --retries=5 --start-period=2s CMD curl --fail http://localhost:8080/health || exit 1
 
-CMD gunicorn -w $WORKER_COUNT -b 0.0.0.0:8080 pdf_service:pdf_service
+CMD exec gunicorn -w $WORKER_COUNT -b 0.0.0.0:8080 pdf_service:pdf_service
 EXPOSE 8080


### PR DESCRIPTION
Otherwise the container cannot be shutdown orderly and will be killed after a 10sec timeout

Also see: https://hynek.me/articles/docker-signals/