### PR TITLE
Use separate image in multi stage build for compiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
 
     container:
       image: mormahr/pdf-service:sha-${{ github.sha }}-testing
-      options: --user root
+      options: --user pdf_service_user
 
     steps:
       - name: Run tests
@@ -118,9 +118,6 @@ jobs:
         with:
           name: Generated test images
           path: /usr/src/app/test-data/*.png
-
-      - name: Install bash for codecov uploader
-        run: apk add bash
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
This removes the need for gcc/g++ in the production image.
Bundle size reduction: 176.68 MB → 115.3 MB (-61,38 MB)