### PR TITLE
Remove unneeded native dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ RUN apk add --no-cache \
       libffi \
       openssl \
       pango \
-      shared-mime-info \
       # fonts
       ttf-opensans \
       ttf-dejavu \


### PR DESCRIPTION
Reduces image size from 60.84 MB → 59.48 MB (-1.36 MB).