### PR TITLE
Drop support for ARM v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           target: production
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
 
       - name: Build and push (testing image)
         uses: docker/build-push-action@v2
@@ -97,7 +97,7 @@ jobs:
           tags: ${{ steps.docker_meta_testing.outputs.tags }}
           labels: ${{ steps.docker_meta_testing.outputs.labels }}
           target: testing
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
 
   build-e2e:
     runs-on: ubuntu-20.04
@@ -162,7 +162,6 @@ jobs:
         platform:
           - "linux/amd64"
           - "linux/arm64"
-          - "linux/arm/v7"
 
     steps:
       - name: Checkout code
@@ -214,7 +213,6 @@ jobs:
         platform:
           - "linux/amd64"
           - "linux/arm64"
-          - "linux/arm/v7"
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Summary: WeasyPrint v53+, ARM multi-arch and much smaller image.
     [#163](https://github.com/mormahr/pdf-service/pull/163)
     [#164](https://github.com/mormahr/pdf-service/pull/164)
     [#165](https://github.com/mormahr/pdf-service/pull/165)
-- Added support for ARM64 (Apple Silicon, AWS Graviton, etc.) and ARMv7 (Raspberry Pi) architectures
+- Added support for ARM64 (Apple Silicon, AWS Graviton, etc.) architecture
     [#162](https://github.com/mormahr/pdf-service/pull/162)
     [#170](https://github.com/mormahr/pdf-service/pull/170)
 - Added support for `data:` URIs

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ running. This endpoint is also configured as a docker [`HEALTHCHECK`][docker-hea
 
 ### Supported architectures
 
-The docker image supports the `linux/amd64` (regular Intel and AMD 64bit processors on x86_64), 
-`linux/arm64` (Apple Silicon, AWS Graviton, etc.) and `linux/arm/v7` (Raspberry Pi) architectures.
+The docker image supports the `linux/amd64` (regular Intel and AMD 64bit processors on x86_64) and 
+`linux/arm64` (Apple Silicon, AWS Graviton, etc.) architectures.
 Image sizes and other information that varies between architectures is taken from the `linux/amd64`
 variant.
 


### PR DESCRIPTION
ARM v7 doesn't build anymore.
This either temporarily or permanently removes support for ARM v7 as a consequence.

Related Issues:
rust-lang/cargo/issues/2808
pyca/cryptography/issues/6673